### PR TITLE
add checkjson:"norecurse" tag

### DIFF
--- a/ex_test.go
+++ b/ex_test.go
@@ -12,14 +12,23 @@ func TestEx(t *testing.T) {
 	{
 		"elem1":"a simple element",
 		"elem2": {
-			"subelem":"something more complex", 
-			"notes"  :"take a look at this" },
+			"subelem":"something more complex",
+			"notes"  :"take a look at this",
+			"strange": {
+				"irr":3,
+				"strange_ex":"extraneous_but_ignore"
+			}
+		},
 	   "elem4":"extraneous" 
 	}`
 
+	type strange struct {
+		Irrelevant int
+	}
 	type sub struct {
 		Subelem string `json:"subelem,omitempty"`
 		Another string `json:"another"`
+		Strange strange `checkjson:"norecurse"`
 	}
 	type elem struct {
 		Elem1 string `json:"elem1"`

--- a/missingkeys_test.go
+++ b/missingkeys_test.go
@@ -158,13 +158,17 @@ func TestJSONKeysWithIgnoreTags(t *testing.T) {
 func TestJSONKeysWithOmitemptyTags(t *testing.T) {
 	fmt.Println("===================== TestJSONKeysWithmitemptyIgnoreTag ...")
 
+	type nested struct {
+		Irrel bool
+	}
 	type test struct {
 		Ok  bool
 		Why string
 		Whynot string `json:",omitempty"`
+		Ignored nested `checkjson:"norecurse"`
 	}
 	tv := test{}
-	data := []byte(`{"ok":true,"why":"it's a test"}`)
+	data := []byte(`{"ok":true,"why":"it's a test","ignored":{"wildcard":"any"}}`)
 
 	IgnoreOmitemptyTag(true)
 	mems, err := MissingJSONKeys(data, tv)


### PR DESCRIPTION
Do not recurse fields with `checkjson:"norecurse"` tag.

Sometimes, some fields might be some kind of "wildcard" that can hold
any JSON structure. Or some third-party library type over which we have
no control. In this case we can add this new tag so that MissingJSONKeys
does not descend those fields, but does check everything else normally.